### PR TITLE
New genscript changes

### DIFF
--- a/src/main/java/com/mathworks/ci/configuration/MatlabTestTaskConfigurator.java
+++ b/src/main/java/com/mathworks/ci/configuration/MatlabTestTaskConfigurator.java
@@ -43,8 +43,14 @@ public class MatlabTestTaskConfigurator extends MatlabTaskConfigurator {
         config.put(MatlabBuilderConstants.JUNIT_FILE, params.getString(MatlabBuilderConstants.JUNIT_FILE));
 
         config.put(MatlabBuilderConstants.STRICT_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.STRICT_CHX)));
-//        config.put(MatlabBuilderConstants.STRICT_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.STRICT_CHX)));
-//        config.put(MatlabBuilderConstants.STRICT, params.getString(MatlabBuilderConstants.STRICT));
+
+        config.put(MatlabBuilderConstants.USE_PARALLEL_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.USE_PARALLEL_CHX)));
+
+        config.put(MatlabBuilderConstants.OUTPUT_DETAIL_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.OUTPUT_DETAIL_CHX)));
+        config.put(MatlabBuilderConstants.OUTPUT_DETAIL_KEY, params.getString(MatlabBuilderConstants.OUTPUT_DETAIL_KEY));
+
+        config.put(MatlabBuilderConstants.LOGGING_LEVEL_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.LOGGING_LEVEL_CHX)));
+        config.put(MatlabBuilderConstants.LOGGING_LEVEL_KEY, params.getString(MatlabBuilderConstants.LOGGING_LEVEL_KEY));
 
         return config;
     }
@@ -87,8 +93,15 @@ public class MatlabTestTaskConfigurator extends MatlabTaskConfigurator {
         context.put(MatlabBuilderConstants.HTML_MODELCOV_FOLDER, taskDefinition.getConfiguration().get(MatlabBuilderConstants.HTML_MODELCOV_FOLDER));
         context.put(MatlabBuilderConstants.HTML_MODELCOV_CHX, taskDefinition.getConfiguration().get(MatlabBuilderConstants.HTML_MODELCOV_CHX));
 
-//        context.put(MatlabBuilderConstants.STRICT, taskDefinition.getConfiguration().get(MatlabBuilderConstants.STRICT));
         context.put(MatlabBuilderConstants.STRICT_CHX, taskDefinition.getConfiguration().get(MatlabBuilderConstants.STRICT_CHX));
+
+        context.put(MatlabBuilderConstants.USE_PARALLEL_CHX, taskDefinition.getConfiguration().get(MatlabBuilderConstants.USE_PARALLEL_CHX));
+
+        context.put(MatlabBuilderConstants.OUTPUT_DETAIL_KEY, taskDefinition.getConfiguration().get(MatlabBuilderConstants.OUTPUT_DETAIL_KEY));
+        context.put(MatlabBuilderConstants.OUTPUT_DETAIL_CHX, taskDefinition.getConfiguration().get(MatlabBuilderConstants.OUTPUT_DETAIL_CHX));
+
+        context.put(MatlabBuilderConstants.LOGGING_LEVEL_KEY, taskDefinition.getConfiguration().get(MatlabBuilderConstants.LOGGING_LEVEL_KEY));
+        context.put(MatlabBuilderConstants.LOGGING_LEVEL_CHX, taskDefinition.getConfiguration().get(MatlabBuilderConstants.LOGGING_LEVEL_CHX));
 
     }
 
@@ -119,8 +132,11 @@ public class MatlabTestTaskConfigurator extends MatlabTaskConfigurator {
         if (params.getBoolean(MatlabBuilderConstants.HTML_MODELCOV_CHX) && (StringUtils.isBlank(params.getString(MatlabBuilderConstants.HTML_MODELCOV_FOLDER)))) {
             errorCollection.addError(MatlabBuilderConstants.HTML_MODELCOV_FOLDER, "Specify a valid location for the HTML model coverage report.");
         }
-//        if (params.getBoolean(MatlabBuilderConstants.STRICT_CHX) && (StringUtils.isBlank(params.getString(MatlabBuilderConstants.STRICT)))) {
-//            errorCollection.addError(MatlabBuilderConstants.STRICT, "Specify a valid input for strict checking.");
-//        }
+        if (params.getBoolean(MatlabBuilderConstants.OUTPUT_DETAIL_CHX) && (StringUtils.isBlank(params.getString(MatlabBuilderConstants.OUTPUT_DETAIL_KEY)))) {
+            errorCollection.addError(MatlabBuilderConstants.OUTPUT_DETAIL_KEY, "Specify a valid display level for Output detail.");
+        }
+        if (params.getBoolean(MatlabBuilderConstants.LOGGING_LEVEL_CHX) && (StringUtils.isBlank(params.getString(MatlabBuilderConstants.LOGGING_LEVEL_KEY)))) {
+            errorCollection.addError(MatlabBuilderConstants.LOGGING_LEVEL_KEY, "Specify a valid maximum verbosity level for Logging diagnostics.");
+        }
     }
 }

--- a/src/main/java/com/mathworks/ci/configuration/MatlabTestTaskConfigurator.java
+++ b/src/main/java/com/mathworks/ci/configuration/MatlabTestTaskConfigurator.java
@@ -46,10 +46,8 @@ public class MatlabTestTaskConfigurator extends MatlabTaskConfigurator {
 
         config.put(MatlabBuilderConstants.USE_PARALLEL_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.USE_PARALLEL_CHX)));
 
-        config.put(MatlabBuilderConstants.OUTPUT_DETAIL_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.OUTPUT_DETAIL_CHX)));
         config.put(MatlabBuilderConstants.OUTPUT_DETAIL_KEY, params.getString(MatlabBuilderConstants.OUTPUT_DETAIL_KEY));
 
-        config.put(MatlabBuilderConstants.LOGGING_LEVEL_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.LOGGING_LEVEL_CHX)));
         config.put(MatlabBuilderConstants.LOGGING_LEVEL_KEY, params.getString(MatlabBuilderConstants.LOGGING_LEVEL_KEY));
 
         return config;
@@ -98,10 +96,8 @@ public class MatlabTestTaskConfigurator extends MatlabTaskConfigurator {
         context.put(MatlabBuilderConstants.USE_PARALLEL_CHX, taskDefinition.getConfiguration().get(MatlabBuilderConstants.USE_PARALLEL_CHX));
 
         context.put(MatlabBuilderConstants.OUTPUT_DETAIL_KEY, taskDefinition.getConfiguration().get(MatlabBuilderConstants.OUTPUT_DETAIL_KEY));
-        context.put(MatlabBuilderConstants.OUTPUT_DETAIL_CHX, taskDefinition.getConfiguration().get(MatlabBuilderConstants.OUTPUT_DETAIL_CHX));
 
         context.put(MatlabBuilderConstants.LOGGING_LEVEL_KEY, taskDefinition.getConfiguration().get(MatlabBuilderConstants.LOGGING_LEVEL_KEY));
-        context.put(MatlabBuilderConstants.LOGGING_LEVEL_CHX, taskDefinition.getConfiguration().get(MatlabBuilderConstants.LOGGING_LEVEL_CHX));
 
     }
 
@@ -131,12 +127,6 @@ public class MatlabTestTaskConfigurator extends MatlabTaskConfigurator {
         }
         if (params.getBoolean(MatlabBuilderConstants.HTML_MODELCOV_CHX) && (StringUtils.isBlank(params.getString(MatlabBuilderConstants.HTML_MODELCOV_FOLDER)))) {
             errorCollection.addError(MatlabBuilderConstants.HTML_MODELCOV_FOLDER, "Specify a valid location for the HTML model coverage report.");
-        }
-        if (params.getBoolean(MatlabBuilderConstants.OUTPUT_DETAIL_CHX) && (StringUtils.isBlank(params.getString(MatlabBuilderConstants.OUTPUT_DETAIL_KEY)))) {
-            errorCollection.addError(MatlabBuilderConstants.OUTPUT_DETAIL_KEY, "Specify a valid display level for Output detail.");
-        }
-        if (params.getBoolean(MatlabBuilderConstants.LOGGING_LEVEL_CHX) && (StringUtils.isBlank(params.getString(MatlabBuilderConstants.LOGGING_LEVEL_KEY)))) {
-            errorCollection.addError(MatlabBuilderConstants.LOGGING_LEVEL_KEY, "Specify a valid maximum verbosity level for Logging diagnostics.");
         }
     }
 }

--- a/src/main/java/com/mathworks/ci/configuration/MatlabTestTaskConfigurator.java
+++ b/src/main/java/com/mathworks/ci/configuration/MatlabTestTaskConfigurator.java
@@ -42,6 +42,10 @@ public class MatlabTestTaskConfigurator extends MatlabTaskConfigurator {
         config.put(MatlabBuilderConstants.JUNIT_RESULTS_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.JUNIT_RESULTS_CHX)));
         config.put(MatlabBuilderConstants.JUNIT_FILE, params.getString(MatlabBuilderConstants.JUNIT_FILE));
 
+        config.put(MatlabBuilderConstants.STRICT_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.STRICT_CHX)));
+//        config.put(MatlabBuilderConstants.STRICT_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.STRICT_CHX)));
+//        config.put(MatlabBuilderConstants.STRICT, params.getString(MatlabBuilderConstants.STRICT));
+
         return config;
     }
 
@@ -83,6 +87,9 @@ public class MatlabTestTaskConfigurator extends MatlabTaskConfigurator {
         context.put(MatlabBuilderConstants.HTML_MODELCOV_FOLDER, taskDefinition.getConfiguration().get(MatlabBuilderConstants.HTML_MODELCOV_FOLDER));
         context.put(MatlabBuilderConstants.HTML_MODELCOV_CHX, taskDefinition.getConfiguration().get(MatlabBuilderConstants.HTML_MODELCOV_CHX));
 
+//        context.put(MatlabBuilderConstants.STRICT, taskDefinition.getConfiguration().get(MatlabBuilderConstants.STRICT));
+        context.put(MatlabBuilderConstants.STRICT_CHX, taskDefinition.getConfiguration().get(MatlabBuilderConstants.STRICT_CHX));
+
     }
 
     @Override
@@ -112,5 +119,8 @@ public class MatlabTestTaskConfigurator extends MatlabTaskConfigurator {
         if (params.getBoolean(MatlabBuilderConstants.HTML_MODELCOV_CHX) && (StringUtils.isBlank(params.getString(MatlabBuilderConstants.HTML_MODELCOV_FOLDER)))) {
             errorCollection.addError(MatlabBuilderConstants.HTML_MODELCOV_FOLDER, "Specify a valid location for the HTML model coverage report.");
         }
+//        if (params.getBoolean(MatlabBuilderConstants.STRICT_CHX) && (StringUtils.isBlank(params.getString(MatlabBuilderConstants.STRICT)))) {
+//            errorCollection.addError(MatlabBuilderConstants.STRICT, "Specify a valid input for strict checking.");
+//        }
     }
 }

--- a/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
@@ -54,8 +54,15 @@ public class MatlabBuilderConstants {
     public static final String HTML_MODELCOV_DEFAULT_DIR = "matlab-artifacts/model-coverage";
 
     //Test run customizations
-//    public static final String STRICT = "strict";
     public static final String STRICT_CHX = "strictChecked";
+
+    public static final String USE_PARALLEL_CHX = "useParallelChecked";
+
+    public static final String OUTPUT_DETAIL_KEY = "outputDetail";
+    public static final String OUTPUT_DETAIL_CHX = "outputDetailChecked";
+
+    public static final String LOGGING_LEVEL_KEY = "loggingLevel";
+    public static final String LOGGING_LEVEL_CHX = "loggingLevelChecked";
 
 
     // Matlab Runner files

--- a/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
@@ -53,6 +53,10 @@ public class MatlabBuilderConstants {
     public static final String HTML_MODELCOV_CHX = "htmlModelCoverageChecked";
     public static final String HTML_MODELCOV_DEFAULT_DIR = "matlab-artifacts/model-coverage";
 
+    //Test run customizations
+//    public static final String STRICT = "strict";
+    public static final String STRICT_CHX = "strictChecked";
+
 
     // Matlab Runner files
     public static final String BAT_RUNNER_FILE = "run_matlab_command.bat";

--- a/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
@@ -59,10 +59,8 @@ public class MatlabBuilderConstants {
     public static final String USE_PARALLEL_CHX = "useParallelChecked";
 
     public static final String OUTPUT_DETAIL_KEY = "outputDetail";
-    public static final String OUTPUT_DETAIL_CHX = "outputDetailChecked";
 
     public static final String LOGGING_LEVEL_KEY = "loggingLevel";
-    public static final String LOGGING_LEVEL_CHX = "loggingLevelChecked";
 
 
     // Matlab Runner files

--- a/src/main/java/com/mathworks/ci/task/MatlabTestTask.java
+++ b/src/main/java/com/mathworks/ci/task/MatlabTestTask.java
@@ -127,11 +127,11 @@ public class MatlabTestTask implements TaskType {
             inputArgsList.add("'UseParallel'" + "," + taskContext.getConfigurationMap().get("useParallelChecked"));
         }
 
-        if (Boolean.parseBoolean(taskContext.getConfigurationMap().get("outputDetailChecked"))) {
+        if (!(taskContext.getConfigurationMap().get("outputDetail").equals("Default"))) {
             inputArgsList.add("'OutputDetail'" + "," + "'" + taskContext.getConfigurationMap().get("outputDetail").trim().replaceAll("'", "''") + "'");
         }
 
-        if (Boolean.parseBoolean(taskContext.getConfigurationMap().get("loggingLevelChecked"))) {
+        if (!(taskContext.getConfigurationMap().get("loggingLevel").equals("Default"))) {
             inputArgsList.add("'LoggingLevel'" + "," + "'" + taskContext.getConfigurationMap().get("loggingLevel").trim().replaceAll("'", "''") + "'");
         }
 

--- a/src/main/java/com/mathworks/ci/task/MatlabTestTask.java
+++ b/src/main/java/com/mathworks/ci/task/MatlabTestTask.java
@@ -115,8 +115,24 @@ public class MatlabTestTask implements TaskType {
             inputArgsList.add("'SelectByTag'" + "," + "'" + taskContext.getConfigurationMap().get("testTag").trim().replaceAll("'", "''") + "'");
         }
 
+        /*
+         * Add test run customization options to argument.
+         * */
+
         if (Boolean.parseBoolean(taskContext.getConfigurationMap().get("strictChecked"))) {
             inputArgsList.add("'Strict'" + "," + taskContext.getConfigurationMap().get("strictChecked"));
+        }
+
+        if (Boolean.parseBoolean(taskContext.getConfigurationMap().get("useParallelChecked"))) {
+            inputArgsList.add("'UseParallel'" + "," + taskContext.getConfigurationMap().get("useParallelChecked"));
+        }
+
+        if (Boolean.parseBoolean(taskContext.getConfigurationMap().get("outputDetailChecked"))) {
+            inputArgsList.add("'OutputDetail'" + "," + "'" + taskContext.getConfigurationMap().get("outputDetail").trim().replaceAll("'", "''") + "'");
+        }
+
+        if (Boolean.parseBoolean(taskContext.getConfigurationMap().get("loggingLevelChecked"))) {
+            inputArgsList.add("'LoggingLevel'" + "," + "'" + taskContext.getConfigurationMap().get("loggingLevel").trim().replaceAll("'", "''") + "'");
         }
 
         return String.join(",", inputArgsList);

--- a/src/main/java/com/mathworks/ci/task/MatlabTestTask.java
+++ b/src/main/java/com/mathworks/ci/task/MatlabTestTask.java
@@ -115,6 +115,10 @@ public class MatlabTestTask implements TaskType {
             inputArgsList.add("'SelectByTag'" + "," + "'" + taskContext.getConfigurationMap().get("testTag").trim().replaceAll("'", "''") + "'");
         }
 
+        if (Boolean.parseBoolean(taskContext.getConfigurationMap().get("strictChecked"))) {
+            inputArgsList.add("'Strict'" + "," + taskContext.getConfigurationMap().get("strictChecked"));
+        }
+
         return String.join(",", inputArgsList);
     }
 }

--- a/src/main/resources/matlab-bamboo-plugin.properties
+++ b/src/main/resources/matlab-bamboo-plugin.properties
@@ -37,7 +37,7 @@ matlab.code.coverage.directory= Folder path
 matlab.test.customizations=Customize test run
 matlab.test.strict=Strict
 matlab.test.use.parallel=Use parallel
-matlab.test.output.detail=Output Detail
+matlab.test.output.detail=Output detail
 matlab.test.logging.level=Logging level
 
 #help links

--- a/src/main/resources/matlab-bamboo-plugin.properties
+++ b/src/main/resources/matlab-bamboo-plugin.properties
@@ -36,6 +36,11 @@ matlab.code.coverage.directory= Folder path
 #Test run customizations
 matlab.test.customizations=Customize test run
 matlab.test.strict=Strict
+matlab.test.use.parallel=Use parallel
+matlab.test.outputDetail.exists=Output Detail
+matlab.test.output.detail=Display level
+matlab.test.loggingLevel.exists=Logging Level
+matlab.test.logging.level=Maximum verbosity level
 
 #help links
 MATLABcommand.task.help.link = https://github.com/mathworks/matlab-bamboo-plugin/blob/master/CONFIGDOC.md#run-matlab-command

--- a/src/main/resources/matlab-bamboo-plugin.properties
+++ b/src/main/resources/matlab-bamboo-plugin.properties
@@ -37,10 +37,8 @@ matlab.code.coverage.directory= Folder path
 matlab.test.customizations=Customize test run
 matlab.test.strict=Strict
 matlab.test.use.parallel=Use parallel
-matlab.test.outputDetail.exists=Output Detail
-matlab.test.output.detail=Display level
-matlab.test.loggingLevel.exists=Logging Level
-matlab.test.logging.level=Maximum verbosity level
+matlab.test.output.detail=Output Detail
+matlab.test.logging.level=Logging level
 
 #help links
 MATLABcommand.task.help.link = https://github.com/mathworks/matlab-bamboo-plugin/blob/master/CONFIGDOC.md#run-matlab-command

--- a/src/main/resources/matlab-bamboo-plugin.properties
+++ b/src/main/resources/matlab-bamboo-plugin.properties
@@ -33,6 +33,10 @@ matlab.test.coverage.exists= HTML code coverage
 matlab.model.coverage.exists= HTML model coverage
 matlab.code.coverage.directory= Folder path
 
+#Test run customizations
+matlab.test.customizations=Customize test run
+matlab.test.strict=Strict
+
 #help links
 MATLABcommand.task.help.link = https://github.com/mathworks/matlab-bamboo-plugin/blob/master/CONFIGDOC.md#run-matlab-command
 MATLABcommand.task.help.title = How to use the Run MATLAB Command task

--- a/src/main/resources/templates/editMATLABTestTask.ftl
+++ b/src/main/resources/templates/editMATLABTestTask.ftl
@@ -30,11 +30,9 @@ extraUtility=addExecutableLink list=uiConfigSupport.getExecutableLabels('matlab'
 
     [@ww.checkbox labelKey='matlab.test.use.parallel' name='useParallelChecked' toggle='true'/]
 
-    [@ww.select cssClass="builderSelectWidget" labelKey="matlab.test.output.detail" name="outputDetail"
-    list=["Default", "None", "Terse", "Concise", "Detailed", "Verbose"]/]
+    [@ww.select labelKey="matlab.test.output.detail" name="outputDetail" list=["Default", "None", "Terse", "Concise", "Detailed", "Verbose"]/]
 
-    [@ww.select cssClass="builderSelectWidget" labelKey="matlab.test.logging.level" name="loggingLevel"
-    list=["Default", "None", "Terse", "Concise", "Detailed", "Verbose"]/]
+    [@ww.select labelKey="matlab.test.logging.level" name="loggingLevel" list=["Default", "None", "Terse", "Concise", "Detailed", "Verbose"]/]
 [/@ui.bambooSection]
 
 [@ui.bambooSection titleKey='matlab.test.artifacts']

--- a/src/main/resources/templates/editMATLABTestTask.ftl
+++ b/src/main/resources/templates/editMATLABTestTask.ftl
@@ -25,6 +25,20 @@ extraUtility=addExecutableLink list=uiConfigSupport.getExecutableLabels('matlab'
         [/@ui.bambooSection]
 [/@ui.bambooSection]
 
+[@ui.bambooSection titleKey='matlab.test.customizations']
+    [@ww.checkbox labelKey='matlab.test.strict' name='strictChecked' toggle='true'/]
+
+    [@ww.checkbox labelKey='matlab.test.use.parallel' name='useParallelChecked' toggle='true'/]
+
+    [@ww.select cssClass="builderSelectWidget" labelKey="matlab.test.output.detail" name="outputDetail"
+    list=["Default", "None", "Terse", "Concise", "Detailed", "Verbose"]/]
+
+    [@ww.select cssClass="builderSelectWidget" labelKey="matlab.test.logging.level" name="loggingLevel"
+    list=["Default", "None", "Terse", "Concise", "Detailed", "Verbose"]/]
+
+    [@ww.select cssClass="builderSelectWidget" labelKey="Sample" list=["a", "b"]/]
+[/@ui.bambooSection]
+
 [@ui.bambooSection titleKey='matlab.test.artifacts']
     [@ww.checkbox labelKey='matlab.test.results.junit' name='junitChecked' toggle='true'/]
         [@ui.bambooSection dependsOn='junitChecked' showOn=true]
@@ -57,24 +71,4 @@ extraUtility=addExecutableLink list=uiConfigSupport.getExecutableLabels('matlab'
             [@ww.textfield labelKey='matlab.code.coverage.directory' name="htmlModel" cssClass="long-field"
             description="Specify a path relative to the working directory." /]
         [/@ui.bambooSection]
-[/@ui.bambooSection]
-
-[@ui.bambooSection titleKey='matlab.test.customizations']
-    [@ww.checkbox labelKey='matlab.test.strict' name='strictChecked' toggle='true'/]
-
-    [@ww.checkbox labelKey='matlab.test.use.parallel' name='useParallelChecked' toggle='true'/]
-
-    [@ww.checkbox labelKey='matlab.test.outputDetail.exists' name='outputDetailChecked' toggle='true'/]
-        [@ui.bambooSection dependsOn='outputDetailChecked' showOn=true]
-[#--            need to update 'matlab' here--]
-            [@ww.select cssClass="builderSelectWidget" labelKey="matlab.test.output.detail" name="outputDetail"
-            list=uiConfigSupport.getExecutableLabels('matlab') required='true'/]
-        [/@ui.bambooSection]
-
-    [@ww.checkbox labelKey='matlab.test.loggingLevel.exists' name='loggingLevelChecked' toggle='true'/]
-    [@ui.bambooSection dependsOn='loggingLevelChecked' showOn=true]
-    [#--            need to update 'matlab' here--]
-        [@ww.select cssClass="builderSelectWidget" labelKey="matlab.test.logging.level" name="loggingLevel"
-        list=uiConfigSupport.getExecutableLabels('matlab') required='true'/]
-    [/@ui.bambooSection]
 [/@ui.bambooSection]

--- a/src/main/resources/templates/editMATLABTestTask.ftl
+++ b/src/main/resources/templates/editMATLABTestTask.ftl
@@ -35,8 +35,6 @@ extraUtility=addExecutableLink list=uiConfigSupport.getExecutableLabels('matlab'
 
     [@ww.select cssClass="builderSelectWidget" labelKey="matlab.test.logging.level" name="loggingLevel"
     list=["Default", "None", "Terse", "Concise", "Detailed", "Verbose"]/]
-
-    [@ww.select cssClass="builderSelectWidget" labelKey="Sample" list=["a", "b"]/]
 [/@ui.bambooSection]
 
 [@ui.bambooSection titleKey='matlab.test.artifacts']

--- a/src/main/resources/templates/editMATLABTestTask.ftl
+++ b/src/main/resources/templates/editMATLABTestTask.ftl
@@ -58,3 +58,7 @@ extraUtility=addExecutableLink list=uiConfigSupport.getExecutableLabels('matlab'
             description="Specify a path relative to the working directory." /]
         [/@ui.bambooSection]
 [/@ui.bambooSection]
+
+[@ui.bambooSection titleKey='matlab.test.customizations']
+    [@ww.checkbox labelKey='matlab.test.strict' name='strictChecked' toggle='true'/]
+[/@ui.bambooSection]

--- a/src/main/resources/templates/editMATLABTestTask.ftl
+++ b/src/main/resources/templates/editMATLABTestTask.ftl
@@ -61,4 +61,20 @@ extraUtility=addExecutableLink list=uiConfigSupport.getExecutableLabels('matlab'
 
 [@ui.bambooSection titleKey='matlab.test.customizations']
     [@ww.checkbox labelKey='matlab.test.strict' name='strictChecked' toggle='true'/]
+
+    [@ww.checkbox labelKey='matlab.test.use.parallel' name='useParallelChecked' toggle='true'/]
+
+    [@ww.checkbox labelKey='matlab.test.outputDetail.exists' name='outputDetailChecked' toggle='true'/]
+        [@ui.bambooSection dependsOn='outputDetailChecked' showOn=true]
+[#--            need to update 'matlab' here--]
+            [@ww.select cssClass="builderSelectWidget" labelKey="matlab.test.output.detail" name="outputDetail"
+            list=uiConfigSupport.getExecutableLabels('matlab') required='true'/]
+        [/@ui.bambooSection]
+
+    [@ww.checkbox labelKey='matlab.test.loggingLevel.exists' name='loggingLevelChecked' toggle='true'/]
+    [@ui.bambooSection dependsOn='loggingLevelChecked' showOn=true]
+    [#--            need to update 'matlab' here--]
+        [@ww.select cssClass="builderSelectWidget" labelKey="matlab.test.logging.level" name="loggingLevel"
+        list=uiConfigSupport.getExecutableLabels('matlab') required='true'/]
+    [/@ui.bambooSection]
 [/@ui.bambooSection]

--- a/src/test/java/com/mathworks/ci/task/MatlabTestTaskTest.java
+++ b/src/test/java/com/mathworks/ci/task/MatlabTestTaskTest.java
@@ -72,8 +72,8 @@ public class MatlabTestTaskTest {
         configurationMap.put("byTagChecked", "false");
         configurationMap.put("strictChecked", "false");
         configurationMap.put("useParallelChecked", "false");
-        configurationMap.put("outputDetailChecked", "false");
-        configurationMap.put("loggingLevelChecked", "false");
+        configurationMap.put("outputDetail", "Default");
+        configurationMap.put("loggingLevel", "Default");
         when(taskContext.getConfigurationMap()).thenReturn(configurationMap);
     }
 
@@ -107,8 +107,6 @@ public class MatlabTestTaskTest {
         configurationMap.put("byTagChecked", "true");
         configurationMap.put("strictChecked", "true");
         configurationMap.put("useParallelChecked", "true");
-        configurationMap.put("outputDetailChecked", "true");
-        configurationMap.put("loggingLevelChecked", "true");
         configurationMap.put("junit", "junit.xml");
         configurationMap.put("pdf", "report.pdf");
         configurationMap.put("html", "code-coverage");

--- a/src/test/java/com/mathworks/ci/task/MatlabTestTaskTest.java
+++ b/src/test/java/com/mathworks/ci/task/MatlabTestTaskTest.java
@@ -70,6 +70,7 @@ public class MatlabTestTaskTest {
         configurationMap.put("srcFolderChecked", "false");
         configurationMap.put("byFolderChecked", "false");
         configurationMap.put("byTagChecked", "false");
+        configurationMap.put("strictChecked", "false");
         when(taskContext.getConfigurationMap()).thenReturn(configurationMap);
     }
 
@@ -101,6 +102,7 @@ public class MatlabTestTaskTest {
         configurationMap.put("srcFolderChecked", "true");
         configurationMap.put("byFolderChecked", "true");
         configurationMap.put("byTagChecked", "true");
+        configurationMap.put("strictChecked", "true");
         configurationMap.put("junit", "junit.xml");
         configurationMap.put("pdf", "report.pdf");
         configurationMap.put("html", "code-coverage");
@@ -127,7 +129,9 @@ public class MatlabTestTaskTest {
             + "'HTMLModelCoverage','model-coverage',"
             + "'SourceFolder','src/:src1',"
             + "'SelectByFolder','test/',"
-            + "'SelectByTag','all');\n\n"
+            + "'SelectByTag','all',"
+            + "'Strict',true);\n\n"
+
             + "disp('Running MATLAB script with contents:');\n"
             + "disp(testScript.Contents);\n"
             + "fprintf('___________________________________\\n\\n');\n" + "run(testScript);\n" + "";

--- a/src/test/java/com/mathworks/ci/task/MatlabTestTaskTest.java
+++ b/src/test/java/com/mathworks/ci/task/MatlabTestTaskTest.java
@@ -71,6 +71,9 @@ public class MatlabTestTaskTest {
         configurationMap.put("byFolderChecked", "false");
         configurationMap.put("byTagChecked", "false");
         configurationMap.put("strictChecked", "false");
+        configurationMap.put("useParallelChecked", "false");
+        configurationMap.put("outputDetailChecked", "false");
+        configurationMap.put("loggingLevelChecked", "false");
         when(taskContext.getConfigurationMap()).thenReturn(configurationMap);
     }
 
@@ -103,6 +106,9 @@ public class MatlabTestTaskTest {
         configurationMap.put("byFolderChecked", "true");
         configurationMap.put("byTagChecked", "true");
         configurationMap.put("strictChecked", "true");
+        configurationMap.put("useParallelChecked", "true");
+        configurationMap.put("outputDetailChecked", "true");
+        configurationMap.put("loggingLevelChecked", "true");
         configurationMap.put("junit", "junit.xml");
         configurationMap.put("pdf", "report.pdf");
         configurationMap.put("html", "code-coverage");
@@ -110,7 +116,9 @@ public class MatlabTestTaskTest {
         configurationMap.put("stm", "results.mldatx");
         configurationMap.put("srcfolder", "src/:src1");
         configurationMap.put("testFolders", "test/");
-        configurationMap.put("testTag", "all");      
+        configurationMap.put("testTag", "all");
+        configurationMap.put("outputDetail", "Detailed");
+        configurationMap.put("loggingLevel", "Detailed");
         when(taskContext.getConfigurationMap()).thenReturn(configurationMap);
 
         try (MockedStatic<TaskResultBuilder> taskResultBuilder = Mockito.mockStatic(TaskResultBuilder.class)) {
@@ -130,7 +138,11 @@ public class MatlabTestTaskTest {
             + "'SourceFolder','src/:src1',"
             + "'SelectByFolder','test/',"
             + "'SelectByTag','all',"
-            + "'Strict',true);\n\n"
+            + "'Strict',true,"
+            + "'UseParallel',true,"
+            + "'OutputDetail','Detailed',"
+            + "'LoggingLevel','Detailed'"
+            + ");\n\n"
 
             + "disp('Running MATLAB script with contents:');\n"
             + "disp(testScript.Contents);\n"


### PR DESCRIPTION
This PR contains the following new Genscript changes:

`useParallel` : Boolean

`strict`: Boolean

`loggingLevel`: String

- Default
- None
- Terse
- Concise
- Detailed
- Verbose 

`outputDetail`: String

- Default
- None
- Terse
- Concise
- Detailed
- Verbose