### PR TITLE
Adding back text for file paths

### DIFF
--- a/src/main/resources/matlab-bamboo-plugin.properties
+++ b/src/main/resources/matlab-bamboo-plugin.properties
@@ -23,6 +23,7 @@ matlab.tests.select.tagName=Tag name
 #Test artifacts
 matlab.test.artifacts=Generate test artifacts
 matlab.test.results.junit=JUnit-style test results
+matlab.tests.results.file=File path
 matlab.tests.results.folder=Folder path
 matlab.test.results.html=HTML test report
 matlab.test.results.pdf=PDF test report


### PR DESCRIPTION
The text for file path labels got removed by accident. Adding back in