### PR TITLE
Add new pipeline to upload release asset

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
           -H "Authorization: Bearer ${GH_TOKEN}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           -H "Content-Type: application/octet-stream" \
-          "https://uploads.github.com/repos/davidbuzinski/bamboo-cd/releases/${{ github.event.release.id }}/assets?name=${PLUGIN_ARTIFACT_NAME}" \
+          "https://uploads.github.com/repos/mathworks/matlab-bamboo-plugin/releases/${{ github.event.release.id }}/assets?name=${PLUGIN_ARTIFACT_NAME}" \
           --data-binary "@${PLUGIN_ARTIFACT_NAME}"
         env:
           GH_TOKEN: "${{ secrets.GH_TOKEN }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Remove SNAPSHOT from pom.xml version
+        run: sed -i 's/-SNAPSHOT//g' pom.xml
+      - name: setup Atlassian SDK
+        run: |
+          sudo sh -c 'echo "deb https://packages.atlassian.com/debian/atlassian-sdk-deb/ stable contrib" >> /etc/apt/sources.list'
+          curl -fL https://packages.atlassian.com/api/gpg/key/public -o public
+          sudo apt-key add public
+          sudo apt-get update
+          sudo apt-get install atlassian-plugin-sdk=8.2.8
+          atlas-version
+      - name: Install dependencies
+        run: atlas-mvn install -q
+      - name: Unit test
+        run: atlas-unit-test
+      - name: Package plugin
+        run: atlas-package
+      - name: Upload plugin as release asset
+        run: |
+          cd target
+          export PLUGIN_ARTIFACT_NAME=$(ls | grep "matlab-bamboo-plugin-[0-9]*.[0-9]*.[0-9]*.jar")
+          echo "Deploying ${PLUGIN_ARTIFACT_NAME} for release ${{ github.event.release.tag_name }}"
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${GH_TOKEN}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          -H "Content-Type: application/octet-stream" \
+          "https://uploads.github.com/repos/davidbuzinski/bamboo-cd/releases/${{ github.event.release.id }}/assets?name=${PLUGIN_ARTIFACT_NAME}" \
+          --data-binary "@${PLUGIN_ARTIFACT_NAME}"
+        env:
+          GH_TOKEN: "${{ secrets.GH_TOKEN }}"
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,6 @@ jobs:
           atlas-version
       - name: Install dependencies
         run: atlas-mvn install -q
-      - name: Unit test
-        run: atlas-unit-test
       - name: Package plugin
         run: atlas-package
       - name: Upload plugin as release asset

--- a/devel/contributing.md
+++ b/devel/contributing.md
@@ -14,8 +14,6 @@ atlas-mvn package
 
 ## Creating a New Release
 
-Familiarize yourself with the best practices for [releasing and maintaining GitHub actions](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions).
-
 Changes should be made on a new branch. The new branch should be merged to the main branch via a pull request. Ensure that all of the CI pipeline checks and tests have passed for your changes.
 
 After the pull request has been approved and merged to main, follow the Github process for [creating a new release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository). The release must follow semantic versioning (ex: vX.Y.Z). This will kick off a new pipeline execution, and the plugin will automatically be uploaded to the new release as a release asset if the pipeline finishes successfully.

--- a/devel/contributing.md
+++ b/devel/contributing.md
@@ -1,0 +1,22 @@
+## Contributing
+To get started, install the [Atlassian SDK](https://developer.atlassian.com/server/framework/atlassian-sdk/install-the-atlassian-sdk-on-a-linux-or-mac-system/):
+
+```
+brew tap atlassian/tap
+brew install atlassian/tap/atlassian-plugin-sdk
+```
+
+Verify changes by running tests and building locally with the following command:
+
+```
+atlas-mvn package
+```
+
+## Creating a New Release
+
+Familiarize yourself with the best practices for [releasing and maintaining GitHub actions](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions).
+
+Changes should be made on a new branch. The new branch should be merged to the main branch via a pull request. Ensure that all of the CI pipeline checks and tests have passed for your changes.
+
+After the pull request has been approved and merged to main, follow the Github process for [creating a new release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository). The release must follow semantic versioning (ex: vX.Y.Z). This will kick off a new pipeline execution, and the plugin will automatically be uploaded to the new release as a release asset if the pipeline finishes successfully.
+


### PR DESCRIPTION
* Added a publish pipeline so that the release process is the same as most of our other CI integrations.
* Added `devel/contributing.md` with simple instructions for getting started and creating a release.