### PR TITLE
Binary update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,17 +166,45 @@
                 <version>1.6.0</version>
                 <executions>
                     <execution>
+                        <id>get-matlab-runner-linux</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/glnxa64/run-matlab-command</url>
+                            <unpack>false</unpack>
+                            <skipCache> true </skipCache>
+                            <overwrite> true </overwrite>
+                            <outputDirectory>${basedir}/src/main/resources/glnxa64</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>get-matlab-runner-mac</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/maci64/run-matlab-command</url>
+                            <unpack>false</unpack>
+                            <skipCache> true </skipCache>
+                            <overwrite> true </overwrite>
+                            <outputDirectory>${basedir}/src/main/resources/maci64</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>get-matlab-runner-scripts</id>
                         <phase>validate</phase>
                         <goals>
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v0/run-matlab-command.zip</url>
-                            <unpack>true</unpack>
+                            <url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/win64/run-matlab-command.exe</url>
+                            <unpack>false</unpack>
                             <skipCache> true </skipCache>
                             <overwrite> true </overwrite>
-                            <outputDirectory>${basedir}/src/main/resources</outputDirectory>
+                            <outputDirectory>${basedir}/src/main/resources/win64</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>get-matlab-runner-scripts</id>
+                        <id>get-matlab-runner-windows</id>
                         <phase>validate</phase>
                         <goals>
                             <goal>wget</goal>

--- a/src/main/java/com/mathworks/ci/configuration/MatlabTaskConfigurator.java
+++ b/src/main/java/com/mathworks/ci/configuration/MatlabTaskConfigurator.java
@@ -43,6 +43,8 @@ public class MatlabTaskConfigurator extends AbstractTaskConfigurator implements 
     public Map<String, String> generateTaskConfigMap(@NotNull final ActionParametersMap params, final TaskDefinition previousTaskDefinition) {
         final Map<String, String> config = super.generateTaskConfigMap(params, previousTaskDefinition);
         config.put(MatlabBuilderConstants.MATLAB_CFG_KEY, params.getString(MatlabBuilderConstants.MATLAB_CFG_KEY));
+        config.put(MatlabBuilderConstants.OPTIONS_CHX, String.valueOf(params.getBoolean(MatlabBuilderConstants.OPTIONS_CHX)));
+        config.put(MatlabBuilderConstants.MATLAB_OPTIONS_KEY, params.getString(MatlabBuilderConstants.MATLAB_OPTIONS_KEY));
         return config;
     }
 
@@ -57,6 +59,8 @@ public class MatlabTaskConfigurator extends AbstractTaskConfigurator implements 
         super.populateContextForEdit(context, taskDefinition);
         populateContextForAll(context);
         context.put(MatlabBuilderConstants.MATLAB_CFG_KEY, taskDefinition.getConfiguration().get(MatlabBuilderConstants.MATLAB_CFG_KEY));
+        context.put(MatlabBuilderConstants.MATLAB_OPTIONS_KEY, taskDefinition.getConfiguration().get(MatlabBuilderConstants.MATLAB_OPTIONS_KEY));
+        context.put(MatlabBuilderConstants.OPTIONS_CHX, taskDefinition.getConfiguration().get(MatlabBuilderConstants.OPTIONS_CHX));
     }
 
     public void populateContextForAll(@NotNull final Map<String, Object> context) {

--- a/src/main/java/com/mathworks/ci/helper/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabBuild.java
@@ -56,24 +56,28 @@ public interface MatlabBuild {
     }
 
     default String getPlatformSpecificRunner(File tempDirectory) throws IOException {
+        String sourceFile;
+        String destinationFile;
         if (SystemUtils.IS_OS_WINDOWS) {
-            copyFileInWorkspace("win64\\run-matlab-command.exe", tempDirectory);
-            return tempDirectory + "\\" + "run-matlab-command.exe";
+            sourceFile = "win64\\run-matlab-command.exe";
+            destinationFile = tempDirectory + "\\" + "run-matlab-command.exe";
         } else if (SystemUtils.IS_OS_MAC) {
-            copyFileInWorkspace("maci64/run-matlab-command", tempDirectory);
-            return tempDirectory + "/" + "run-matlab-command";
+            sourceFile = "maci64/run-matlab-command";
+            destinationFile = tempDirectory + "/" + "run-matlab-command";
         } else {
-            copyFileInWorkspace("glnxa64/run-matlab-command", tempDirectory);
-            return tempDirectory + "/" + "run-matlab-command";
+            sourceFile = "glnxa64/run-matlab-command";
+            destinationFile = tempDirectory + "/" + "run-matlab-command";
         }
+        copyFileInWorkspace(sourceFile, destinationFile);
+        return destinationFile;
     }
 
     /*
      * Method to copy given file from source to target node specific workspace.
      */
-    default void copyFileInWorkspace(String sourceFile, File targetWorkspace) throws IOException {
+    default void copyFileInWorkspace(String sourceFile, String destinationFile) throws IOException {
         final ClassLoader classLoader = getClass().getClassLoader();
-        final File destination = new File(targetWorkspace, new File(sourceFile).getName());
+        final File destination = new File(destinationFile);
         InputStream in = classLoader.getResourceAsStream(sourceFile);
         OutputStream outputStream = new FileOutputStream(destination);
         IOUtils.copy(in, outputStream);

--- a/src/main/java/com/mathworks/ci/helper/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabBuild.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 - 2022 The MathWorks, Inc.
+ * Copyright 2020 - 2023 The MathWorks, Inc.
  */
 
 package com.mathworks.ci.helper;

--- a/src/main/java/com/mathworks/ci/helper/MatlabBuild.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabBuild.java
@@ -57,11 +57,14 @@ public interface MatlabBuild {
 
     default String getPlatformSpecificRunner(File tempDirectory) throws IOException {
         if (SystemUtils.IS_OS_WINDOWS) {
-            copyFileInWorkspace(MatlabBuilderConstants.BAT_RUNNER_FILE, tempDirectory);
-            return tempDirectory + "\\" + "run_matlab_command.bat";
+            copyFileInWorkspace("win64\\run-matlab-command.exe", tempDirectory);
+            return tempDirectory + "\\" + "run-matlab-command.exe";
+        } else if (SystemUtils.IS_OS_MAC) {
+            copyFileInWorkspace("maci64/run-matlab-command", tempDirectory);
+            return tempDirectory + "/" + "run-matlab-command";
         } else {
-            copyFileInWorkspace(MatlabBuilderConstants.SHELL_RUNNER_FILE, tempDirectory);
-            return tempDirectory + "/" + "run_matlab_command.sh";
+            copyFileInWorkspace("glnxa64/run-matlab-command", tempDirectory);
+            return tempDirectory + "/" + "run-matlab-command";
         }
     }
 
@@ -70,7 +73,7 @@ public interface MatlabBuild {
      */
     default void copyFileInWorkspace(String sourceFile, File targetWorkspace) throws IOException {
         final ClassLoader classLoader = getClass().getClassLoader();
-        final File destination = new File(targetWorkspace, sourceFile);
+        final File destination = new File(targetWorkspace, new File(sourceFile).getName());
         InputStream in = classLoader.getResourceAsStream(sourceFile);
         OutputStream outputStream = new FileOutputStream(destination);
         IOUtils.copy(in, outputStream);

--- a/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
@@ -70,17 +70,9 @@ public class MatlabBuilderConstants {
 
     public static final String LOGGING_LEVEL_KEY = "loggingLevel";
 
-
-    // Matlab Runner files
-    public static final String BAT_RUNNER_FILE = "run_matlab_command.bat";
-    public static final String SHELL_RUNNER_FILE = "run_matlab_command.sh";
-
     // MATLAB runner script
     public static final String TEST_RUNNER_SCRIPT = "testScript = genscript(${PARAMS});\n" + "\n"
             + "disp('Running MATLAB script with contents:');\n"
             + "disp(testScript.Contents);\n"
             + "fprintf('___________________________________\\n\\n');\n" + "run(testScript);\n" + "";
-
-    //Test runner file prefix
-    public static final String MATLAB_TEST_RUNNER_FILE_PREFIX = "test_runner_";
 }

--- a/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
@@ -9,6 +9,10 @@ public class MatlabBuilderConstants {
     public static final String MATLAB_PREFIX = "system.builder.matlab.";
     public static final String MATLAB_CAPABILITY_PREFIX = "system.builder.matlab.MATLAB ";
     public static final String MATLAB_CFG_KEY = "matlabExecutable";
+    
+    // Startup options keys
+    public static final String MATLAB_OPTIONS_KEY = "matlabOptions";
+    public static final String OPTIONS_CHX = "optionsChecked";
 
     // UIConfigBean populated in Configurators by Bamboo
     public static final String UI_CONFIG_SUPPORT = "uiConfigSupport";

--- a/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 The MathWorks, Inc.
+ * Copyright 2020-2023 The MathWorks, Inc.
  */
 
 package com.mathworks.ci.helper;

--- a/src/main/java/com/mathworks/ci/helper/MatlabCommandRunner.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabCommandRunner.java
@@ -38,12 +38,10 @@ public class MatlabCommandRunner implements MatlabBuild {
         String matlabRoot = getMatlabRoot(taskContext, capabilityContext, buildLogger);
         buildLogger.addBuildLogEntry("Running MATLAB command: " + matlabCommand);
         List<String> command = generateCommand(matlabCommand, workingDirectory);
-        System.out.println(taskContext.getConfigurationMap().get(MatlabBuilderConstants.OPTIONS_CHX));
         if (Boolean.parseBoolean(taskContext.getConfigurationMap().get(MatlabBuilderConstants.OPTIONS_CHX))) {
             String startupOpts = taskContext.getConfigurationMap().get(MatlabBuilderConstants.MATLAB_OPTIONS_KEY);
             command.add(startupOpts);
         }
-        System.out.println("After check");
         ExternalProcessBuilder processBuilder = new ExternalProcessBuilder()
             .workingDirectory(workingDirectory)
             .command(command)

--- a/src/main/java/com/mathworks/ci/helper/MatlabCommandRunner.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabCommandRunner.java
@@ -53,8 +53,8 @@ public class MatlabCommandRunner implements MatlabBuild {
 
     public void unzipToTempDir(String zipName) throws IOException {
         // copy zip to tempDirectory
-        copyFileInWorkspace(zipName, tempDirectory);
         File zipFileLocation = new File(tempDirectory, zipName);
+        copyFileInWorkspace(zipName, zipFileLocation.toString());
 
         // Unzip the file to temp folder
         ZipFile zipFile = new ZipFile(zipFileLocation);

--- a/src/main/java/com/mathworks/ci/helper/MatlabCommandRunner.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabCommandRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 The MathWorks, Inc.
+ * Copyright 2022-2023 The MathWorks, Inc.
  */
 
 package com.mathworks.ci.helper;

--- a/src/main/java/com/mathworks/ci/helper/MatlabCommandRunner.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabCommandRunner.java
@@ -38,6 +38,12 @@ public class MatlabCommandRunner implements MatlabBuild {
         String matlabRoot = getMatlabRoot(taskContext, capabilityContext, buildLogger);
         buildLogger.addBuildLogEntry("Running MATLAB command: " + matlabCommand);
         List<String> command = generateCommand(matlabCommand, workingDirectory);
+        System.out.println(taskContext.getConfigurationMap().get(MatlabBuilderConstants.OPTIONS_CHX));
+        if (Boolean.parseBoolean(taskContext.getConfigurationMap().get(MatlabBuilderConstants.OPTIONS_CHX))) {
+            String startupOpts = taskContext.getConfigurationMap().get(MatlabBuilderConstants.MATLAB_OPTIONS_KEY);
+            command.add(startupOpts);
+        }
+        System.out.println("After check");
         ExternalProcessBuilder processBuilder = new ExternalProcessBuilder()
             .workingDirectory(workingDirectory)
             .command(command)

--- a/src/main/java/com/mathworks/ci/task/MatlabBuildTask.java
+++ b/src/main/java/com/mathworks/ci/task/MatlabBuildTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 The MathWorks, Inc.
+ * Copyright 2022-2023 The MathWorks, Inc.
  * 
  * Run MATLAB Build Task Invocation
  */

--- a/src/main/resources/matlab-bamboo-plugin.properties
+++ b/src/main/resources/matlab-bamboo-plugin.properties
@@ -5,6 +5,8 @@ matlab.plugin.command=Command
 plugin.command.error=Command field is empty.
 
 matlab.helpPath = Full path to MATLAB root folder
+matlab.options = Startup options
+matlab.options.field = Options
 
 # MATLAB Build keys
 matlab.build.tasks = Build tasks

--- a/src/main/resources/matlab-bamboo-plugin.properties
+++ b/src/main/resources/matlab-bamboo-plugin.properties
@@ -5,7 +5,7 @@ matlab.plugin.command=Command
 plugin.command.error=Command field is empty.
 
 matlab.helpPath = Full path to MATLAB root folder
-matlab.options = Startup options
+matlab.options = Specify startup options
 matlab.options.field = Options
 
 # MATLAB Build keys

--- a/src/main/resources/templates/editMATLABBuildTask.ftl
+++ b/src/main/resources/templates/editMATLABBuildTask.ftl
@@ -6,6 +6,6 @@ extraUtility=addExecutableLink  list=uiConfigSupport.getExecutableLabels('matlab
     [@ww.checkbox labelKey='matlab.options' name='optionsChecked'  toggle='true'/]
         [@ui.bambooSection dependsOn='optionsChecked' showOn=true]
             [@ww.textfield labelKey='matlab.options.field' cssClass="long-field" name="matlabOptions"
-                description="Specify MATLAB startup options."/]
+                description="Specify MATLAB startup options as a space-separated list."/]
         [/@ui.bambooSection]
 [/@ui.bambooSection]

--- a/src/main/resources/templates/editMATLABBuildTask.ftl
+++ b/src/main/resources/templates/editMATLABBuildTask.ftl
@@ -2,3 +2,10 @@
 [@ww.select cssClass="builderSelectWidget" labelKey="executable.type" name="matlabExecutable"
 extraUtility=addExecutableLink  list=uiConfigSupport.getExecutableLabels('matlab') required='true'/]
 [@ww.textfield labelKey='matlab.build.tasks' name='buildTasks' cssClass="long-field" description="Specify the MATLAB build tasks to execute." required='false'/]
+[@ui.bambooSection]
+    [@ww.checkbox labelKey='matlab.options' name='optionsChecked'  toggle='true'/]
+        [@ui.bambooSection dependsOn='optionsChecked' showOn=true]
+            [@ww.textfield labelKey='matlab.options.field' cssClass="long-field" name="matlabOptions"
+                description="Specify MATLAB startup options."/]
+        [/@ui.bambooSection]
+[/@ui.bambooSection]

--- a/src/main/resources/templates/editMATLABBuildTask.ftl
+++ b/src/main/resources/templates/editMATLABBuildTask.ftl
@@ -1,7 +1,7 @@
 [#assign addExecutableLink][@ui.displayAddExecutableInline executableKey='matlab'/][/#assign]
 [@ww.select cssClass="builderSelectWidget" labelKey="executable.type" name="matlabExecutable"
 extraUtility=addExecutableLink  list=uiConfigSupport.getExecutableLabels('matlab') required='true'/]
-[@ww.textfield labelKey='matlab.build.tasks' name='buildTasks' cssClass="long-field" description="Specify the MATLAB build tasks to execute." required='false'/]
+
 [@ui.bambooSection]
     [@ww.checkbox labelKey='matlab.options' name='optionsChecked'  toggle='true'/]
         [@ui.bambooSection dependsOn='optionsChecked' showOn=true]
@@ -9,3 +9,5 @@ extraUtility=addExecutableLink  list=uiConfigSupport.getExecutableLabels('matlab
                 description="Specify MATLAB startup options as a space-separated list."/]
         [/@ui.bambooSection]
 [/@ui.bambooSection]
+
+[@ww.textfield labelKey='matlab.build.tasks' name='buildTasks' cssClass="long-field" description="Specify the MATLAB build tasks to execute." required='false'/]

--- a/src/main/resources/templates/editMATLABCommandTask.ftl
+++ b/src/main/resources/templates/editMATLABCommandTask.ftl
@@ -6,6 +6,6 @@ extraUtility=addExecutableLink  list=uiConfigSupport.getExecutableLabels('matlab
     [@ww.checkbox labelKey='matlab.options' name='optionsChecked'  toggle='true'/]
         [@ui.bambooSection dependsOn='optionsChecked' showOn=true]
             [@ww.textfield labelKey='matlab.options.field' cssClass="long-field" name="matlabOptions"
-                description="Specify MATLAB startup options."/]
+                description="Specify MATLAB startup options as a space-separated list."/]
         [/@ui.bambooSection]
 [/@ui.bambooSection]

--- a/src/main/resources/templates/editMATLABCommandTask.ftl
+++ b/src/main/resources/templates/editMATLABCommandTask.ftl
@@ -1,7 +1,7 @@
 [#assign addExecutableLink][@ui.displayAddExecutableInline executableKey='matlab'/][/#assign]
 [@ww.select cssClass="builderSelectWidget" labelKey="executable.type" name="matlabExecutable"
 extraUtility=addExecutableLink  list=uiConfigSupport.getExecutableLabels('matlab') required='true'/]
-[@ww.textfield labelKey='matlab.plugin.command' name='matlabCommand' cssClass="long-field" description="Specify the MATLAB command to execute." required='true'/]
+
 [@ui.bambooSection]
     [@ww.checkbox labelKey='matlab.options' name='optionsChecked'  toggle='true'/]
         [@ui.bambooSection dependsOn='optionsChecked' showOn=true]
@@ -9,3 +9,5 @@ extraUtility=addExecutableLink  list=uiConfigSupport.getExecutableLabels('matlab
                 description="Specify MATLAB startup options as a space-separated list."/]
         [/@ui.bambooSection]
 [/@ui.bambooSection]
+
+[@ww.textfield labelKey='matlab.plugin.command' name='matlabCommand' cssClass="long-field" description="Specify the MATLAB command to execute." required='true'/]

--- a/src/main/resources/templates/editMATLABCommandTask.ftl
+++ b/src/main/resources/templates/editMATLABCommandTask.ftl
@@ -2,3 +2,10 @@
 [@ww.select cssClass="builderSelectWidget" labelKey="executable.type" name="matlabExecutable"
 extraUtility=addExecutableLink  list=uiConfigSupport.getExecutableLabels('matlab') required='true'/]
 [@ww.textfield labelKey='matlab.plugin.command' name='matlabCommand' cssClass="long-field" description="Specify the MATLAB command to execute." required='true'/]
+[@ui.bambooSection]
+    [@ww.checkbox labelKey='matlab.options' name='optionsChecked'  toggle='true'/]
+        [@ui.bambooSection dependsOn='optionsChecked' showOn=true]
+            [@ww.textfield labelKey='matlab.options.field' cssClass="long-field" name="matlabOptions"
+                description="Specify MATLAB startup options."/]
+        [/@ui.bambooSection]
+[/@ui.bambooSection]

--- a/src/main/resources/templates/editMATLABTestTask.ftl
+++ b/src/main/resources/templates/editMATLABTestTask.ftl
@@ -11,6 +11,14 @@ extraUtility=addExecutableLink list=uiConfigSupport.getExecutableLabels('matlab'
         [/@ui.bambooSection]
 [/@ui.bambooSection]
 
+[@ui.bambooSection]
+    [@ww.checkbox labelKey='matlab.options' name='optionsChecked'  toggle='true'/]
+        [@ui.bambooSection dependsOn='optionsChecked' showOn=true]
+            [@ww.textfield labelKey='matlab.options.field' cssClass="long-field" name="matlabOptions"
+                description="Specify MATLAB startup options as a space-separated list."/]
+        [/@ui.bambooSection]
+[/@ui.bambooSection]
+
 [@ui.bambooSection titleKey='matlab.test.selection']
     [@ww.checkbox labelKey='matlab.test.select.byfolder' name='byFolderChecked' toggle='true'/]
         [@ui.bambooSection dependsOn='byFolderChecked' showOn=true]
@@ -75,10 +83,3 @@ extraUtility=addExecutableLink list=uiConfigSupport.getExecutableLabels('matlab'
         [/@ui.bambooSection]
 [/@ui.bambooSection]
 
-[@ui.bambooSection]
-    [@ww.checkbox labelKey='matlab.options' name='optionsChecked'  toggle='true'/]
-        [@ui.bambooSection dependsOn='optionsChecked' showOn=true]
-            [@ww.textfield labelKey='matlab.options.field' cssClass="long-field" name="matlabOptions"
-                description="Specify MATLAB startup options."/]
-        [/@ui.bambooSection]
-[/@ui.bambooSection]

--- a/src/main/resources/templates/editMATLABTestTask.ftl
+++ b/src/main/resources/templates/editMATLABTestTask.ftl
@@ -3,19 +3,19 @@
 extraUtility=addExecutableLink list=uiConfigSupport.getExecutableLabels('matlab') required='true'/]
 
 [@ui.bambooSection]
+    [@ww.checkbox labelKey='matlab.options' name='optionsChecked'  toggle='true'/]
+        [@ui.bambooSection dependsOn='optionsChecked' showOn=true]
+            [@ww.textfield labelKey='matlab.options.field' cssClass="long-field" name="matlabOptions"
+                description="Specify MATLAB startup options as a space-separated list."/]
+        [/@ui.bambooSection]
+[/@ui.bambooSection]
+
+[@ui.bambooSection]
     [@ww.checkbox labelKey='matlab.test.srcfolder.exists' name='srcFolderChecked'  toggle='true'/]
         [@ui.bambooSection dependsOn='srcFolderChecked' showOn=true]
             [@ww.textfield labelKey='matlab.tests.source.folder' cssClass="long-field" name="srcfolder"
                 description="Specify the locations of folders containing source code, relative to the working
                 directory,<br> as a colon-separated or semicolon-separated list.<br> "/]
-        [/@ui.bambooSection]
-[/@ui.bambooSection]
-
-[@ui.bambooSection]
-    [@ww.checkbox labelKey='matlab.options' name='optionsChecked'  toggle='true'/]
-        [@ui.bambooSection dependsOn='optionsChecked' showOn=true]
-            [@ww.textfield labelKey='matlab.options.field' cssClass="long-field" name="matlabOptions"
-                description="Specify MATLAB startup options as a space-separated list."/]
         [/@ui.bambooSection]
 [/@ui.bambooSection]
 

--- a/src/main/resources/templates/editMATLABTestTask.ftl
+++ b/src/main/resources/templates/editMATLABTestTask.ftl
@@ -74,3 +74,11 @@ extraUtility=addExecutableLink list=uiConfigSupport.getExecutableLabels('matlab'
             description="Specify a path relative to the working directory." /]
         [/@ui.bambooSection]
 [/@ui.bambooSection]
+
+[@ui.bambooSection]
+    [@ww.checkbox labelKey='matlab.options' name='optionsChecked'  toggle='true'/]
+        [@ui.bambooSection dependsOn='optionsChecked' showOn=true]
+            [@ww.textfield labelKey='matlab.options.field' cssClass="long-field" name="matlabOptions"
+                description="Specify MATLAB startup options."/]
+        [/@ui.bambooSection]
+[/@ui.bambooSection]

--- a/src/test/java/com/mathworks/ci/helper/MatlabBuildTest.java
+++ b/src/test/java/com/mathworks/ci/helper/MatlabBuildTest.java
@@ -58,19 +58,6 @@ public class MatlabBuildTest {
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
-    private String runnerScript;
-    private String runnerFile;
-    private File tempFile;
-    private File tempFolder;
-
-    @Before
-    public void init() throws IOException {
-        runnerScript = SystemUtils.IS_OS_WINDOWS ? "run_matlab_command.bat" : "./run_matlab_command.sh";
-        runnerFile = SystemUtils.IS_OS_WINDOWS ? "run_matlab_command.bat" : "run_matlab_command.sh";
-        tempFile = testFolder.newFile("temp_File");
-        tempFolder = testFolder.newFolder("temp_Folder");
-    }
-
     @Test
     public void testGetMatlabRoot() {
         CapabilityImpl capability = new CapabilityImpl("system.builder.matlab.R2019b", "local-ssd/Downloads/R2019b");
@@ -82,18 +69,5 @@ public class MatlabBuildTest {
         when(capabilityContext.getCapabilitySet()).thenReturn(capabilitySet);
         when(taskContext.getConfigurationMap()).thenReturn(configurationMap);
         assertEquals(matlabCommandRunner.getMatlabRoot(taskContext, capabilityContext, buildlogger), "local-ssd/Downloads/R2019b/bin");
-    }
-
-    @Test
-    public void testGetTempWorkingDirectory() {
-        when(matlabBuild.getTempWorkingDirectory()).thenReturn(tempFile);
-        assertEquals(matlabBuild.getTempWorkingDirectory(), tempFile);
-    }
-
-
-    @Test
-    public void testGetPlatformSpecificRunner() throws IOException {
-        when(matlabBuild.getPlatformSpecificRunner(tempFolder)).thenReturn(runnerScript);
-        assertEquals(matlabBuild.getPlatformSpecificRunner(tempFolder), runnerScript);
     }
 }

--- a/src/test/java/com/mathworks/ci/helper/MatlabBuildTest.java
+++ b/src/test/java/com/mathworks/ci/helper/MatlabBuildTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 - 2022 The MathWorks, Inc.
+ * Copyright 2020 - 2023 The MathWorks, Inc.
  */
 
 package com.mathworks.ci.task;

--- a/src/test/java/com/mathworks/ci/helper/MatlabCommandRunnerTest.java
+++ b/src/test/java/com/mathworks/ci/helper/MatlabCommandRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 The MathWorks, Inc.
+ * Copyright 2022-2023 The MathWorks, Inc.
  */
 
 package com.mathworks.ci.helper;

--- a/src/test/java/com/mathworks/ci/helper/MatlabCommandRunnerTest.java
+++ b/src/test/java/com/mathworks/ci/helper/MatlabCommandRunnerTest.java
@@ -67,6 +67,7 @@ public class MatlabCommandRunnerTest {
 
         ConfigurationMapImpl configurationMap = new ConfigurationMapImpl();
         configurationMap.put(MatlabBuilderConstants.MATLAB_CFG_KEY, "R2019b");
+        configurationMap.put(MatlabBuilderConstants.OPTIONS_CHX, "false");
 
         when(capabilityContext.getCapabilitySet()).thenReturn(capabilitySet);
         when(taskContext.getConfigurationMap()).thenReturn(configurationMap);


### PR DESCRIPTION
Update the Bamboo plugin to use the `run-matlab-command` binary. Additionally add a field for entering MATLAB startup options to maintain parity with other CI/CD services.