### PR TITLE
Update icu4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,14 @@
             <artifactId>gson</artifactId>
             <version>2.10.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>68.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+
     </dependencies>
 
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -112,8 +112,6 @@
             <version>68.2</version>
             <scope>provided</scope>
         </dependency>
-
-
     </dependencies>
 
     <pluginRepositories>


### PR DESCRIPTION
The original icu4j.jar causes a java issue. Overriding the icu4j.jar with a later version in pom.xml.