### PR TITLE
Add the fix for the sd flag

### DIFF
--- a/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabBuilderConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2023 The MathWorks, Inc.
+ * Copyright 2020-2024 The MathWorks, Inc.
  */
 
 package com.mathworks.ci.helper;
@@ -71,7 +71,8 @@ public class MatlabBuilderConstants {
     public static final String LOGGING_LEVEL_KEY = "loggingLevel";
 
     // MATLAB runner script
-    public static final String TEST_RUNNER_SCRIPT = "testScript = genscript(${PARAMS});\n" + "\n"
+    public static final String TEST_RUNNER_SCRIPT = "addpath('${TEMPFOLDER}');\n"
+            + "testScript = genscript(${PARAMS});\n" 
             + "disp('Running MATLAB script with contents:');\n"
             + "disp(testScript.Contents);\n"
             + "fprintf('___________________________________\\n\\n');\n" + "run(testScript);\n" + "";

--- a/src/main/java/com/mathworks/ci/helper/MatlabCommandRunner.java
+++ b/src/main/java/com/mathworks/ci/helper/MatlabCommandRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2023 The MathWorks, Inc.
+ * Copyright 2022-2024 The MathWorks, Inc.
  */
 
 package com.mathworks.ci.helper;
@@ -27,6 +27,10 @@ public class MatlabCommandRunner implements MatlabBuild {
     private File tempDirectory = getTempWorkingDirectory();
     private final CapabilityContext capabilityContext;
     private final ProcessService processService;
+
+    public File getTempDirectory() {
+        return this.tempDirectory;
+    }
 
     public MatlabCommandRunner(ProcessService processService, CapabilityContext capabilityContext) {
         this.capabilityContext = capabilityContext;
@@ -72,7 +76,7 @@ public class MatlabCommandRunner implements MatlabBuild {
         List<String> command = new ArrayList<>();
         final String uniqueCommandFile =
             "matlab_" + UUID.randomUUID().toString().replaceAll("-", "_");
-        String commandToExecute = "addpath('" + tempDirectory.toString().replaceAll("'", "''") + "');" + uniqueCommandFile;
+        String commandToExecute = "setenv('MW_ORIG_WORKING_FOLDER', cd('" + tempDirectory.toString().replaceAll("'", "''") + "'));" + uniqueCommandFile;
 
         // Create MATLAB script
         createMatlabScriptByName(matlabCommand, workingDirectory, tempDirectory, uniqueCommandFile);
@@ -86,7 +90,7 @@ public class MatlabCommandRunner implements MatlabBuild {
         final File matlabCommandFile =
             new File(uniqeTmpFolderPath, uniqueScriptName + ".m");
         final String matlabCommandFileContent =
-            "cd '" + workingDirectory.toString().replaceAll("'", "''") + "';\n" + command;
+            "cd(getenv('MW_ORIG_WORKING_FOLDER'));\n" + command;
         BufferedWriter writer = new BufferedWriter(new FileWriter(matlabCommandFile));
         writer.write(matlabCommandFileContent);
         writer.close();

--- a/src/main/java/com/mathworks/ci/task/MatlabTestTask.java
+++ b/src/main/java/com/mathworks/ci/task/MatlabTestTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 The MathWorks, Inc.
+ * Copyright 2020-2024 The MathWorks, Inc.
  * 
  * Run MATLAB Test Task Invocation
  */
@@ -50,7 +50,8 @@ public class MatlabTestTask implements TaskType {
         BuildLogger buildLogger = taskContext.getBuildLogger();
 
         String matlabTestOptions = getInputArguments(taskContext);
-        String testCommand = getRunnerScript(MatlabBuilderConstants.TEST_RUNNER_SCRIPT, matlabTestOptions);
+        String tempFolder = matlabCommandRunner.getTempDirectory().getAbsolutePath();
+        String testCommand = getRunnerScript(MatlabBuilderConstants.TEST_RUNNER_SCRIPT, matlabTestOptions, tempFolder);
 
         buildLogger.addBuildLogEntry("Running MATLAB tests: ");
         try {
@@ -65,7 +66,8 @@ public class MatlabTestTask implements TaskType {
         return taskResultBuilder.build();
     }
 
-    String getRunnerScript(String script, String params) {
+    String getRunnerScript(String script, String params, String tempFolder) {
+        script = script.replace("${TEMPFOLDER}", tempFolder);
         script = script.replace("${PARAMS}", params);
         return script;
     }

--- a/src/test/java/com/mathworks/ci/helper/MatlabCommandRunnerTest.java
+++ b/src/test/java/com/mathworks/ci/helper/MatlabCommandRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2023 The MathWorks, Inc.
+ * Copyright 2022-2024 The MathWorks, Inc.
  */
 
 package com.mathworks.ci.helper;
@@ -109,6 +109,19 @@ public class MatlabCommandRunnerTest {
     }
 
     @Test
+    public void testRunSetsOrigFolderEnvVariable() throws TaskException, IOException {
+        ConfigurationMapImpl configurationMap = new ConfigurationMapImpl();
+        configurationMap.put(MatlabBuilderConstants.MATLAB_CFG_KEY, "R2019b");
+
+        matlabCommandRunner.run("myScript", taskContext);
+
+        ArgumentCaptor<ExternalProcessBuilder> captor = ArgumentCaptor.forClass(ExternalProcessBuilder.class);
+        Mockito.verify(processService).createExternalProcess(Mockito.any(TaskContext.class), captor.capture());
+        List<String> arg = captor.getValue().getCommand();
+        assertTrue(arg.get(1).contains("setenv('MW_ORIG_WORKING_FOLDER', cd('"));
+    }
+
+    @Test
     public void testRunIgnoresOptionsWhenUnchecked() throws TaskException, IOException {
         ConfigurationMapImpl configurationMap = new ConfigurationMapImpl();
         configurationMap.put(MatlabBuilderConstants.MATLAB_CFG_KEY, "R2019b");
@@ -121,7 +134,7 @@ public class MatlabCommandRunnerTest {
         ArgumentCaptor<ExternalProcessBuilder> captor = ArgumentCaptor.forClass(ExternalProcessBuilder.class);
         Mockito.verify(processService).createExternalProcess(Mockito.any(TaskContext.class), captor.capture());
         List<String> arg = captor.getValue().getCommand();
-        assertFalse(arg.contains("-nojvm -display -logfile myfile.log"));
+        assertFalse(arg.containsAll(Arrays.asList("-nojvm -display -logfile myfile.log")));
     }
 
     @Test

--- a/src/test/java/com/mathworks/ci/task/MatlabTestTaskTest.java
+++ b/src/test/java/com/mathworks/ci/task/MatlabTestTaskTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 The MathWorks, Inc.
+ * Copyright 2022-2024 The MathWorks, Inc.
  */
 
 package com.mathworks.ci.task;
@@ -76,6 +76,7 @@ public class MatlabTestTaskTest {
         configurationMap.put("outputDetail", "Default");
         configurationMap.put("loggingLevel", "Default");
         when(taskContext.getConfigurationMap()).thenReturn(configurationMap);
+        when(matlabCommandRunner.getTempDirectory()).thenReturn(new File("/path/to/.matlab"));
     }
 
     @Test
@@ -88,7 +89,8 @@ public class MatlabTestTaskTest {
         ArgumentCaptor<String> matlabCommand = ArgumentCaptor.forClass(String.class);
         Mockito.verify(matlabCommandRunner).run(matlabCommand.capture(), Mockito.any());
 
-        String expectedCommand = "testScript = genscript('Test');\n\n"
+        String expectedCommand = "addpath('/path/to/.matlab');\n" 
+            + "testScript = genscript('Test');\n"
             + "disp('Running MATLAB script with contents:');\n"
             + "disp(testScript.Contents);\n"
             + "fprintf('___________________________________\\n\\n');\n" + "run(testScript);\n" + "";
@@ -130,7 +132,8 @@ public class MatlabTestTaskTest {
         ArgumentCaptor<String> matlabCommand = ArgumentCaptor.forClass(String.class);
         Mockito.verify(matlabCommandRunner).run(matlabCommand.capture(), Mockito.any());
 
-        String expectedCommand = "testScript = genscript("
+        String expectedCommand = "addpath('/path/to/.matlab');\n"
+            + "testScript = genscript("
             + "'Test','JUnitTestResults','junit.xml',"
             + "'HTMLTestReport','test-reports',"
             + "'PDFTestReport','report.pdf',"
@@ -144,8 +147,7 @@ public class MatlabTestTaskTest {
             + "'UseParallel',true,"
             + "'OutputDetail','Detailed',"
             + "'LoggingLevel','Detailed'"
-            + ");\n\n"
-
+            + ");\n"
             + "disp('Running MATLAB script with contents:');\n"
             + "disp(testScript.Contents);\n"
             + "fprintf('___________________________________\\n\\n');\n" + "run(testScript);\n" + "";


### PR DESCRIPTION
Some background for why I kind of took the long way around of removing `addpath` from `MatlabCommandRunner` and moved it to the code specific to the test task:

We've generally been trying to avoid adding to the path when we can because it changes the state in a way that is visible to the customer. As such, it's better to not modify the path for the two tasks that don't need it and just add it for the test task. 