### PR TITLE
Update plugin publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: setup Atlassian SDK
         run: |
           sudo sh -c 'echo "deb https://packages.atlassian.com/debian/atlassian-sdk-deb/ stable contrib" >> /etc/apt/sources.list'
@@ -29,7 +29,7 @@ jobs:
       - name: Package plugin
         run: atlas-package
       - name: Upload plugin as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: matlab-bamboo-plugin
           path: target/matlab-bamboo-plugin-*-SNAPSHOT.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: Install dependencies
         run: atlas-mvn install -q
       - name: Unit test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install atlassian-plugin-sdk=8.2.8
           atlas-version
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Install dependencies
         run: atlas-mvn install -q
       - name: Unit test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions: 
+      contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Remove SNAPSHOT from pom.xml version
         run: sed -i 's/-SNAPSHOT//g' pom.xml
       - name: setup Atlassian SDK
@@ -24,19 +26,9 @@ jobs:
         run: atlas-mvn install -q
       - name: Package plugin
         run: atlas-package
-      - name: Upload plugin as release asset
+      - name: Upload release asset
         run: |
-          cd target
-          export PLUGIN_ARTIFACT_NAME=$(ls | grep "matlab-bamboo-plugin-[0-9]*.[0-9]*.[0-9]*.jar")
-          echo "Deploying ${PLUGIN_ARTIFACT_NAME} for release ${{ github.event.release.tag_name }}"
-          curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${GH_TOKEN}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          -H "Content-Type: application/octet-stream" \
-          "https://uploads.github.com/repos/mathworks/matlab-bamboo-plugin/releases/${{ github.event.release.id }}/assets?name=${PLUGIN_ARTIFACT_NAME}" \
-          --data-binary "@${PLUGIN_ARTIFACT_NAME}"
+          export PLUGIN_ARTIFACT_NAME=$(ls target | grep "matlab-bamboo-plugin-[0-9]*.[0-9]*.[0-9]*.jar")
+          gh release upload ${{ github.event.release.tag_name }} target/$PLUGIN_ARTIFACT_NAME
         env:
-          GH_TOKEN: "${{ secrets.GH_TOKEN }}"
-
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - name: Remove SNAPSHOT from pom.xml version
-        run: sed -i 's/-SNAPSHOT//g' pom.xml
       - name: setup Atlassian SDK
         run: |
           sudo sh -c 'echo "deb https://packages.atlassian.com/debian/atlassian-sdk-deb/ stable contrib" >> /etc/apt/sources.list'
@@ -22,13 +20,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install atlassian-plugin-sdk=8.2.8
           atlas-version
+      - name: Set plugin version in pom.xml
+        run: |
+          export MATLAB_PLUGIN_VERSION=$(echo ${{ github.event.release.tag_name }} | sed 's/[^0-9\.]*//g')
+          echo "MATLAB_PLUGIN_VERSION=$MATLAB_PLUGIN_VERSION" >> $GITHUB_ENV
+          atlas-mvn versions:set -DnewVersion=$MATLAB_PLUGIN_VERSION
       - name: Install dependencies
         run: atlas-mvn install -q
       - name: Package plugin
         run: atlas-package
       - name: Upload release asset
         run: |
-          export PLUGIN_ARTIFACT_NAME=$(ls target | grep "matlab-bamboo-plugin-[0-9]*.[0-9]*.[0-9]*.jar")
-          gh release upload ${{ github.event.release.tag_name }} target/$PLUGIN_ARTIFACT_NAME
+          gh release upload ${{ github.event.release.tag_name }} target/matlab-bamboo-plugin-$MATLAB_PLUGIN_VERSION.jar
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install atlassian-plugin-sdk=8.2.8
           atlas-version
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Set plugin version in pom.xml
         run: |
           export MATLAB_PLUGIN_VERSION=$(echo ${{ github.event.release.tag_name }} | sed 's/[^0-9\.]*//g')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: Set plugin version in pom.xml
         run: |
           export MATLAB_PLUGIN_VERSION=$(echo ${{ github.event.release.tag_name }} | sed 's/[^0-9\.]*//g')


### PR DESCRIPTION
The plugin will be published to a release created through the Releases GitHub GUI:

Key changes:
* Use `gh` cli that is included on all GitHub Actions runners by default
* Use version from release tag to set version in pom.xml
* Use the GitHub token associated with the job so we don't have to worry about it
* Update checkout action version