### PR TITLE
Update publish to use new java version and mvn cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,12 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - name: Install JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 21
+          cache: maven
       - name: setup Atlassian SDK
         run: |
           sudo sh -c 'echo "deb https://packages.atlassian.com/debian/atlassian-sdk-deb/ stable contrib" >> /etc/apt/sources.list'
@@ -20,11 +26,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install atlassian-plugin-sdk=8.2.8
           atlas-version
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
       - name: Set plugin version in pom.xml
         run: |
           export MATLAB_PLUGIN_VERSION=$(echo ${{ github.event.release.tag_name }} | sed 's/[^0-9\.]*//g')


### PR DESCRIPTION
My automatic publish no longer worked after the changes to fix compatibility for Bamboo 10.X