### PR TITLE
Make sure MATLAB doesn't show up 3 times in help menu and add back in capabilityDefaultsHelper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <bamboo.version>10.2.1</bamboo.version>
         <bamboo.data.version>10.2.1</bamboo.data.version>
-        <amps.version>9.1.4</amps.version>
+        <amps.version>9.4.0</amps.version>
         <plugin.testrunner.version>2.0.9</plugin.testrunner.version>
         <atlassian.spring.scanner.version>5.0.2</atlassian.spring.scanner.version>
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -30,7 +30,9 @@
         <description>Run a build using the MATLAB build tool</description>
         <category name="builder"/>
         <configuration class="com.mathworks.ci.configuration.MatlabBuildTaskConfigurator"/>
-        <executable key="matlab" nameKey="MATLAB" pathHelpKey="matlab.helpPath"/>
+        <!-- Ensure primaryCapabilityProvider is false because it is already provided by runMATLABCommand -->
+        <executable key="matlab" nameKey="MATLAB" primaryCapabilityProvider="false" pathHelpKey="matlab.helpPath"/>
+        <capabilityDefaultsHelper class="com.mathworks.ci.MatlabCapabilityDefaultsHelper"/>
         <resource type="freemarker" name="edit" location="templates/editMATLABBuildTask.ftl"/>
         <resource type="download" name="icon" location="images/image1.png"/>
         <help link="MATLABbuild.task.help.link" title="MATLABbuild.task.help.title" />
@@ -42,6 +44,7 @@
         <category name="builder"/>
         <configuration class="com.mathworks.ci.configuration.MatlabCommandTaskConfigurator"/>
         <executable key="matlab" nameKey="MATLAB" pathHelpKey="matlab.helpPath"/>
+        <capabilityDefaultsHelper class="com.mathworks.ci.MatlabCapabilityDefaultsHelper"/>
         <resource type="freemarker" name="edit" location="/templates/editMATLABCommandTask.ftl"/>
         <resource type="download" name="icon" location="images/image1.png"/>
         <help link="MATLABcommand.task.help.link" title="MATLABcommand.task.help.title" />
@@ -53,7 +56,9 @@
         <description>Run all MATLAB tests and generate test artifacts</description>
         <category name="test"/>
         <configuration class="com.mathworks.ci.configuration.MatlabTestTaskConfigurator"/>
-        <executable key="matlab" nameKey="MATLAB" pathHelpKey="matlab.helpPath"/>
+        <!-- Ensure primaryCapabilityProvider is false because it is already provided by runMATLABCommand -->
+        <executable key="matlab" nameKey="MATLAB" primaryCapabilityProvider="false" pathHelpKey="matlab.helpPath"/>
+        <capabilityDefaultsHelper class="com.mathworks.ci.MatlabCapabilityDefaultsHelper"/>
         <resource type="freemarker" name="edit" location="templates/editMATLABTestTask.ftl"/>
         <resource type="download" name="icon" location="images/image1.png"/>
         <help link="MATLABtest.task.help.link" title="MATLABtest.task.help.title" />

--- a/src/test/java/com/mathworks/ci/task/MatlabTestTaskTest.java
+++ b/src/test/java/com/mathworks/ci/task/MatlabTestTaskTest.java
@@ -90,7 +90,8 @@ public class MatlabTestTaskTest {
         ArgumentCaptor<String> matlabCommand = ArgumentCaptor.forClass(String.class);
         Mockito.verify(matlabCommandRunner).run(matlabCommand.capture(), Mockito.any());
 
-        String expectedCommand = "addpath('/path/to/.matlab');\n" 
+        String expectedPath = new File("/path/to/.matlab").getAbsolutePath();
+        String expectedCommand = "addpath('" + expectedPath + "');\n" 
             + "testScript = genscript('Test');\n"
             + "disp('Running MATLAB script with contents:');\n"
             + "disp(testScript.Contents);\n"
@@ -133,7 +134,8 @@ public class MatlabTestTaskTest {
         ArgumentCaptor<String> matlabCommand = ArgumentCaptor.forClass(String.class);
         Mockito.verify(matlabCommandRunner).run(matlabCommand.capture(), Mockito.any());
 
-        String expectedCommand = "addpath('/path/to/.matlab');\n"
+        String expectedPath = new File("/path/to/.matlab").getAbsolutePath();
+        String expectedCommand = "addpath('" + expectedPath + "');\n"
             + "testScript = genscript("
             + "'Test','JUnitTestResults','junit.xml',"
             + "'HTMLTestReport','test-reports',"


### PR DESCRIPTION
Solves issue raised by Yiting in https://github.com/mathworks/matlab-bamboo-plugin/issues/44 by making sure MATLAB is provided as a primary capability once.

It looks like we had the auto-detect code written already but it was misconfigured. Added back in the capability defaults helper reference.